### PR TITLE
Updated Docker workflow to pull image from repository instead of buil…

### DIFF
--- a/.github/actions/pull_docker_image/action.yml
+++ b/.github/actions/pull_docker_image/action.yml
@@ -5,25 +5,15 @@ inputs:
   image:
     description: The docker image to pull
     required: true
-    default: kmake-image:latest
+    default: kmake-image:ver.1.0
 
 runs:
   using: "composite"
   steps:
-    - name: Clone kmake-image
+    - name: Pull Docker image
       shell: bash
       run: |
-        git clone https://github.com/qualcomm-linux/kmake-image.git
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    
-    - name: Build and push
-      uses: docker/build-push-action@v6
-      with:
-        push: false
-        load: true
-        tags: kmake-image:latest
-        context: kmake-image
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        echo "Pulling Docker image: ${{ inputs.image }}"
+        docker pull artifacts.codelinaro.org/clo-420-qli-registry/${{ inputs.image }}
+        echo "Docker image pulled successfully:"
+        docker tag artifacts.codelinaro.org/clo-420-qli-registry/${{ inputs.image }} kmake-image:ver.1.0

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -7,11 +7,11 @@ jobs:
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
-      docker_image: kmake-image:latest
+      docker_image: kmake-image:ver.1.0
 
   test:
     needs: [build]
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
-      docker_image: kmake-image:latest
+      docker_image: kmake-image:ver.1.0


### PR DESCRIPTION
…ding

Replaced the previous Docker image-building process with a direct pull from the repository. Now using: `docker pull artifacts.codelinaro.org/clo-420-qli-registry/kmake-image:ver.1.0` This enhances efficiency by leveraging pre-built images, reducing build time, and ensuring consistency across environments.